### PR TITLE
Fix download URL retrieval for Linux

### DIFF
--- a/linux/linux_install.sh
+++ b/linux/linux_install.sh
@@ -9,21 +9,30 @@ ARCH=$(uname -m)
 
 # Function to fetch the latest release information from Aide Updates API
 fetch_latest_version() {
+    extract_download_url_from_release_info_for() {
+        target=${1}
+        printf '%s' "$(
+            printf '%s' "${release_info}" |
+                grep "${target}" |
+                sed "s/^.*\"${target}\":\"\([[:alnum:]:/.-]\+\)\".*$/\1/"
+        )"
+    }
+
     echo "Fetching the latest Aide release information..."
     release_info=$(curl -s https://aide-updates.codestory.ai/api/all/stable)
 
     # Extract URLs based on architecture
     case "$ARCH" in
-        x86_64)
-            BIN_URL=$(echo "$release_info" | grep '"linux_x64"' | cut -d'"' -f4)
-            ;;
-        aarch64)
-            BIN_URL=$(echo "$release_info" | grep '"linux_arm64"' | cut -d'"' -f4)
-            ;;
-        *)
-            echo "Unsupported architecture: $ARCH"
-            exit 1
-            ;;
+    x86_64)
+        BIN_URL="$(extract_download_url_from_release_info_for 'linux_x64')"
+        ;;
+    aarch64)
+        BIN_URL="$(extract_download_url_from_release_info_for 'linux_arm64')"
+        ;;
+    *)
+        printf 'Unsupported architecture: %s\n' "${ARCH}"
+        exit 1
+        ;;
     esac
 
     if [[ -z "$BIN_URL" ]]; then


### PR DESCRIPTION
The function `fetch_latest_version` was updated to correctly retrieve the architecture specific download URL from a release info response.

It appears that the previous solution was based on the assumption that each URL in the response JSON would be in its own line, but for now the whole response is in a single line. My proposed solution works for both single-line and multi-line JSON response.

It should be noted that the regular expression `[[:alnum:]:/.-]\+` used with sed will cause the script to fail in case the download URLs will contain some other characters than digits, letters, colon (`:`), slash (`/`), dot (`.`) and hyphen (`-`).
Probably a better alternative would be to use the regular expression `[^\"]\+` to match every character except double quotes (`"`) which are unlikely to be used for download URLs.
A bit simpler and more reliable solution would be to use jq (for example: `jq .linux_x64`), but that unfortunately would also be an additional dependency since not all systems have jq installed by default.